### PR TITLE
Add Python dependencies list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+# JEOD project Python requirements
+# This file lists third-party packages used by scripts
+# throughout the repository. Version numbers are not fixed
+# but the packages should be compatible with Python 3.6+.
+
+numpy
+matplotlib
+h5py
+mako
+regex
+metrixpp


### PR DESCRIPTION
## Summary
- document JEOD Python module dependencies in new `requirements.txt`

## Testing
- `pytest -q` *(fails: NameError: trick not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6845e1f3874083229e650037b5a6b801