### PR TITLE
Add state helpers and sprint tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dep_jeod_*
 trickified/python*
 regression/logs
 build*
+!jeod_helpers/builder.py
 artifacts
 
 #documentation build products

--- a/SPRINT_TRACKER.md
+++ b/SPRINT_TRACKER.md
@@ -1,0 +1,16 @@
+# Sprint Tracker
+
+| Sprint | Objective | Status |
+|-------|-----------|--------|
+| 1 | Packaging & Version Setup | ✔ Done |
+| 2 | Library Skeleton | ✔ Done |
+| 3 | Vehicle Initialization Helpers | ✔ Done |
+| 4 | State Initialization Utilities | ✔ Done |
+| 5 | Gravity Control Wrappers | ☐ Pending |
+| 6 | Logging and Event Helpers | ☐ Pending |
+| 7 | Input File Builder Class | ☐ Pending |
+| 8 | CLI Interface | ☐ Pending |
+| 9 | Testing & Continuous Integration | ☐ Pending |
+| 10 | Example Usage & Documentation | ☐ Pending |
+
+This tracker records sprint objectives and their completion status.

--- a/SPRINT_TRACKER.md
+++ b/SPRINT_TRACKER.md
@@ -6,7 +6,7 @@
 | 2 | Library Skeleton | ✔ Done |
 | 3 | Vehicle Initialization Helpers | ✔ Done |
 | 4 | State Initialization Utilities | ✔ Done |
-| 5 | Gravity Control Wrappers | ☐ Pending |
+| 5 | Gravity Control Wrappers | ✔ Done |
 | 6 | Logging and Event Helpers | ☐ Pending |
 | 7 | Input File Builder Class | ☐ Pending |
 | 8 | CLI Interface | ☐ Pending |

--- a/jeod_helpers/CHANGELOG.md
+++ b/jeod_helpers/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.1] - Vehicle helpers
+- Added `JeodHelperError` exception class.
+- Implemented `create_dyn_body`, `set_mass_properties`, and `attach_body` with logging.
+
+## [0.1.0] - Initial release
+- Package scaffold with version metadata.

--- a/jeod_helpers/CHANGELOG.md
+++ b/jeod_helpers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.2] - State and gravity helpers
+- Added translation and rotation state utilities with unit handling.
+- Added gravity configuration helpers including spherical harmonics.
+
 ## [0.1.1] - Vehicle helpers
 - Added `JeodHelperError` exception class.
 - Implemented `create_dyn_body`, `set_mass_properties`, and `attach_body` with logging.

--- a/jeod_helpers/README.md
+++ b/jeod_helpers/README.md
@@ -14,5 +14,7 @@ pip install -e .
 from jeod_helpers import __version__, vehicles
 
 body = vehicles.create_dyn_body("vehicle1", mass=500.0, inertia=(1, 1, 1))
+from jeod_helpers import gravity
+gravity.enable_spherical_gravity(body)
 print(__version__, body)
 ```

--- a/jeod_helpers/README.md
+++ b/jeod_helpers/README.md
@@ -1,0 +1,18 @@
+# JEOD Helpers
+
+Utility functions for building Trick input files programmatically.
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+## Basic Usage
+
+```python
+from jeod_helpers import __version__, vehicles
+
+body = vehicles.create_dyn_body("vehicle1", mass=500.0, inertia=(1, 1, 1))
+print(__version__, body)
+```

--- a/jeod_helpers/__init__.py
+++ b/jeod_helpers/__init__.py
@@ -18,7 +18,7 @@ __all__ = [
     "events",
     "builder",
 ]
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 logger = logging.getLogger(__name__)
 

--- a/jeod_helpers/__init__.py
+++ b/jeod_helpers/__init__.py
@@ -1,0 +1,32 @@
+"""JEOD input helper utilities.
+
+This package provides helper functions and builders to simplify
+construction of Trick simulation input files.
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+__all__ = [
+    "__version__",
+    "JeodHelperError",
+    "vehicles",
+    "states",
+    "gravity",
+    "events",
+    "builder",
+]
+__version__ = "0.1.1"
+
+logger = logging.getLogger(__name__)
+
+
+class JeodHelperError(Exception):
+    """Exception raised for invalid helper input."""
+
+
+
+from . import builder, events, gravity, states, vehicles
+

--- a/jeod_helpers/builder.py
+++ b/jeod_helpers/builder.py
@@ -1,0 +1,31 @@
+"""Input file builder for JEOD simulations.
+
+This module defines a placeholder ``InputBuilder`` class that will chain helper
+calls when constructing Trick input files.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List
+
+logger = logging.getLogger(__name__)
+
+
+class InputBuilder:
+    """Collects actions to build a Trick input file."""
+
+    def __init__(self) -> None:
+        self.actions: List[Any] = []
+        logger.debug("InputBuilder initialized")
+
+    def add_action(self, action: Any) -> "InputBuilder":
+        """Record an action for later execution."""
+        logger.debug("Adding action %s", action)
+        self.actions.append(action)
+        return self
+
+    def build(self) -> List[Any]:
+        """Return the collected actions."""
+        logger.debug("Building with %d actions", len(self.actions))
+        return self.actions

--- a/jeod_helpers/cli.py
+++ b/jeod_helpers/cli.py
@@ -1,0 +1,30 @@
+"""Command-line interface for jeod_helpers."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", action="store_true", help="Show package version")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    if args.version:
+        from . import __version__
+
+        print(__version__)
+    else:
+        parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/jeod_helpers/events.py
+++ b/jeod_helpers/events.py
@@ -1,0 +1,13 @@
+"""Event scheduling helpers."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def schedule_event(time: float, action: str):
+    """Schedule a simple string action at simulation time."""
+    logger.debug("Scheduling event %s at t=%s", action, time)
+    return {"time": time, "action": action}

--- a/jeod_helpers/gravity.py
+++ b/jeod_helpers/gravity.py
@@ -1,0 +1,27 @@
+"""Gravity configuration helpers."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def enable_spherical_gravity(body, planet: str = "earth"):
+    """Enable simple spherical gravity for a body placeholder."""
+    logger.debug("Enabling spherical gravity for %s around %s", getattr(body, "name", body), planet)
+    body.setdefault("gravity", {})["type"] = "spherical"
+    body["gravity"]["planet"] = planet
+
+
+def enable_spherical_harmonics(body, degree: int, order: int, planet: str = "earth"):
+    """Enable spherical harmonics gravity."""
+    logger.debug(
+        "Enabling harmonics for %s deg=%s order=%s planet=%s",
+        getattr(body, "name", body),
+        degree,
+        order,
+        planet,
+    )
+    body.setdefault("gravity", {})["type"] = "harmonics"
+    body["gravity"].update({"degree": degree, "order": order, "planet": planet})

--- a/jeod_helpers/gravity.py
+++ b/jeod_helpers/gravity.py
@@ -4,24 +4,53 @@ from __future__ import annotations
 
 import logging
 
+from . import JeodHelperError
+
 logger = logging.getLogger(__name__)
 
 
 def enable_spherical_gravity(body, planet: str = "earth"):
     """Enable simple spherical gravity for a body placeholder."""
-    logger.debug("Enabling spherical gravity for %s around %s", getattr(body, "name", body), planet)
+    logger.info(
+        "Enabling spherical gravity for %s around %s",
+        getattr(body, "name", body),
+        planet,
+    )
     body.setdefault("gravity", {})["type"] = "spherical"
     body["gravity"]["planet"] = planet
 
 
-def enable_spherical_harmonics(body, degree: int, order: int, planet: str = "earth"):
+def enable_spherical_harmonics(
+    body, degree: int, order: int, planet: str = "earth"
+):
     """Enable spherical harmonics gravity."""
-    logger.debug(
+    logger.info(
         "Enabling harmonics for %s deg=%s order=%s planet=%s",
         getattr(body, "name", body),
         degree,
         order,
         planet,
     )
+    if degree <= 0 or order <= 0:
+        raise JeodHelperError("degree and order must be positive")
+
     body.setdefault("gravity", {})["type"] = "harmonics"
     body["gravity"].update({"degree": degree, "order": order, "planet": planet})
+
+
+def configure_gravity_controls(
+    body,
+    *,
+    use_harmonics: bool = False,
+    degree: int | None = None,
+    order: int | None = None,
+    planet: str = "earth",
+):
+    """General gravity control wrapper with fail-soft validation."""
+    if use_harmonics:
+        if degree is None or order is None:
+            raise JeodHelperError("degree and order required for harmonics")
+        enable_spherical_harmonics(body, degree, order, planet)
+    else:
+        enable_spherical_gravity(body, planet)
+    return body

--- a/jeod_helpers/states.py
+++ b/jeod_helpers/states.py
@@ -1,0 +1,101 @@
+"""State initialization helpers for JEOD simulations."""
+
+from __future__ import annotations
+
+import logging
+from typing import Sequence
+
+from . import JeodHelperError
+
+logger = logging.getLogger(__name__)
+
+
+def _attach_units(units: str, value: Sequence[float]):
+    """Return a value with Trick units attached if available."""
+    try:
+        from trick import sim_services
+
+        return sim_services.attach_units(units, value)
+    except Exception:  # pragma: no cover - Trick not installed
+        logger.debug("attach_units fallback for %s", units)
+        return list(value)
+
+
+def set_trans_state(
+    body,
+    position: Sequence[float],
+    velocity: Sequence[float],
+    *,
+    pos_units: str = "m",
+    vel_units: str = "m/s",
+):
+    """Set the translational state of a body placeholder.
+
+    Parameters
+    ----------
+    body : object
+        Body placeholder.
+    position : Sequence[float]
+        Position vector.
+    velocity : Sequence[float]
+        Velocity vector.
+    pos_units : str, optional
+        Units for the position vector, by default "m".
+    vel_units : str, optional
+        Units for the velocity vector, by default "m/s".
+    """
+    if len(position) != 3 or len(velocity) != 3:
+        logger.warning("Bad state vector lengths pos=%s vel=%s", position, velocity)
+        raise JeodHelperError("Position and velocity must be 3-element sequences")
+
+    logger.info(
+        "Setting translation for %s pos=%s %s vel=%s %s",
+        getattr(body, "name", body),
+        position,
+        pos_units,
+        velocity,
+        vel_units,
+    )
+    body["position"] = _attach_units(pos_units, position)
+    body["velocity"] = _attach_units(vel_units, velocity)
+
+
+def set_rot_state(
+    body,
+    quaternion: Sequence[float],
+    rates: Sequence[float],
+    *,
+    quat_units: str = "dimensionless",
+    rate_units: str = "rad/s",
+):
+    """Set the rotational state of a body placeholder.
+
+    Parameters
+    ----------
+    body : object
+        Body placeholder.
+    quaternion : Sequence[float]
+        Attitude quaternion ``[x, y, z, w]``.
+    rates : Sequence[float]
+        Body rates.
+    quat_units : str, optional
+        Units for the quaternion, usually dimensionless.
+    rate_units : str, optional
+        Units for the angular velocity, by default ``"rad/s"``.
+    """
+    if len(quaternion) != 4 or len(rates) != 3:
+        logger.warning("Bad rotation vector lengths quat=%s rates=%s", quaternion, rates)
+        raise JeodHelperError("Quaternion must have 4 elements and rates 3")
+
+    logger.info(
+        "Setting rotation for %s quat=%s %s rates=%s %s",
+        getattr(body, "name", body),
+        quaternion,
+        quat_units,
+        rates,
+        rate_units,
+    )
+    body["quaternion"] = _attach_units(quat_units, quaternion)
+    body["rates"] = _attach_units(rate_units, rates)
+
+    return body

--- a/jeod_helpers/vehicles.py
+++ b/jeod_helpers/vehicles.py
@@ -1,0 +1,105 @@
+"""Vehicle creation helpers for JEOD simulations.
+
+This module will provide utility functions for building and configuring
+`DynBody` objects used within Trick input files.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Sequence
+
+from . import JeodHelperError
+
+logger = logging.getLogger(__name__)
+
+
+def create_dyn_body(name: str, *, mass: float | None = None, inertia: Sequence[float] | None = None):
+    """Create a bare DynBody placeholder.
+
+    Parameters
+    ----------
+    name : str
+        The name of the body to create.
+
+    Returns
+    -------
+    object
+        Placeholder for a Trick DynBody instance.
+    """
+    logger.info("Creating DynBody: %s", name)
+    body = {"name": name, "children": []}
+    if mass is not None and inertia is not None:
+        set_mass_properties(body, mass, inertia)
+    elif mass is not None or inertia is not None:
+        logger.warning("Both mass and inertia required to set properties; ignoring")
+    return body
+
+
+def set_mass_properties(body, mass: float, inertia: Sequence[float]):
+    """Assign mass properties to a DynBody placeholder.
+
+    Parameters
+    ----------
+    body : object
+        The body object to modify.
+    mass : float
+        Mass value in kilograms.
+    inertia : Sequence[float]
+        Moments of inertia. Accepts 3 values ``(Ixx, Iyy, Izz)`` for a
+        diagonal inertia tensor, 6 values ``(Ixx, Ixy, Ixz, Iyy, Iyz, Izz)``
+        for a symmetric tensor, or 9 values providing the full 3x3 matrix
+        in row-major order.
+    """
+    logger.info(
+        "Setting mass properties for %s",
+        getattr(body, "name", body),
+    )
+    if mass <= 0:
+        raise JeodHelperError("Mass must be positive")
+    if len(inertia) not in (3, 6, 9):
+        raise JeodHelperError("Inertia must have 3, 6, or 9 elements")
+
+    body["mass"] = mass
+    if len(inertia) == 3:
+        Ixx, Iyy, Izz = inertia
+        inertia_matrix = [
+            [Ixx, 0.0, 0.0],
+            [0.0, Iyy, 0.0],
+            [0.0, 0.0, Izz],
+        ]
+    elif len(inertia) == 6:
+        Ixx, Ixy, Ixz, Iyy, Iyz, Izz = inertia
+        inertia_matrix = [
+            [Ixx, Ixy, Ixz],
+            [Ixy, Iyy, Iyz],
+            [Ixz, Iyz, Izz],
+        ]
+    else:
+        inertia_matrix = [
+            list(inertia[0:3]),
+            list(inertia[3:6]),
+            list(inertia[6:9]),
+        ]
+
+    body["inertia"] = inertia_matrix
+    logger.debug("Inertia matrix for %s: %s", getattr(body, "name", body), inertia_matrix)
+
+
+def attach_body(parent, child):
+    """Attach one body to another in the dynamics tree.
+
+    Parameters
+    ----------
+    parent : object
+        Parent body.
+    child : object
+        Child body to attach.
+    """
+    logger.info(
+        "Attaching %s to %s",
+        getattr(child, "name", child),
+        getattr(parent, "name", parent),
+    )
+    parent.setdefault("children", []).append(child)
+    logger.debug("%s now has %d children", getattr(parent, "name", parent), len(parent["children"]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "jeod_helpers"
+version = "0.1.1"
+description = "JEOD input helper utilities"
+readme = "jeod_helpers/README.md"
+license = {text = "NASA Open Source Agreement 1.3"}
+authors = [{name = "JEOD Team"}]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: NASA Open Source Agreement 1.3",
+]
+
+# Additional project metadata
+dependencies = []
+
+[project.scripts]
+jeod-helpers = "jeod_helpers.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jeod_helpers"
-version = "0.1.1"
+version = "0.1.2"
 description = "JEOD input helper utilities"
 readme = "jeod_helpers/README.md"
 license = {text = "NASA Open Source Agreement 1.3"}


### PR DESCRIPTION
## Summary
- add fallback attach_units utility and validations for state helpers
- store units in placeholders and raise JeodHelperError on bad input
- track sprint progress in new SPRINT_TRACKER.md

## Testing
- `python -m py_compile jeod_helpers/__init__.py jeod_helpers/vehicles.py jeod_helpers/states.py jeod_helpers/gravity.py jeod_helpers/events.py jeod_helpers/builder.py jeod_helpers/cli.py`
- `pytest -q` *(fails: NameError: name 'trick' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6845cf44e9e08322b5f9d492df1fe91a